### PR TITLE
Fix undefined exception by defining empty function

### DIFF
--- a/foundrysync/classes/oauth2/api.php
+++ b/foundrysync/classes/oauth2/api.php
@@ -4,7 +4,9 @@ namespace tool_foundrysync\oauth2;
 
 class api extends \core\oauth2\api {
 
-//public static function discover_endpoints($issuer) {}
+    public static function discover_endpoints($issuer) {
+        // TODO - decide if this should be implemented
+    }
 
     public static function create_issuer($data) {
         $issuer = new \core\oauth2\issuer(0, $data);


### PR DESCRIPTION
Running API commands tries to call `discover_endpoints` which was commented out, resulting in an unhandled exception.  

Instead of removing the code completely, I decided to just have it be an empty function, to preserve the knowledge that `discover_endpoints` might someday be necessary to implement.