### PR TITLE
Update to work with new OAuth2 code

### DIFF
--- a/foundrysync/classes/oauth2/api.php
+++ b/foundrysync/classes/oauth2/api.php
@@ -13,7 +13,8 @@ class api extends \core\oauth2\api {
         $issuer->create();
 
         // Perform service discovery.
-        self::discover_endpoints($issuer);
+        $classname = self::get_service_classname($issuer->get('servicetype'));
+        $classname::discover_endpoints($issuer);
         self::guess_image($issuer);
         return $issuer;
     }
@@ -25,7 +26,8 @@ class api extends \core\oauth2\api {
         $issuer->update();
 
         // Perform service discovery.
-        self::discover_endpoints($issuer);
+        $classname = self::get_service_classname($issuer->get('servicetype'));
+        $classname::discover_endpoints($issuer);
         self::guess_image($issuer);
         return $issuer;
     }


### PR DESCRIPTION
The Moodle OAuth2 code changed, and the `discover_endpoints` moved with it.  

Our issuers do not set a `servicetype` specifically, so the default of `core\oauth2\service\custom` gets returned from `get_service_classname` as seen [here](https://github.com/moodle/moodle/blob/911f9adccfc032af277fe3befd02ad5a99cbde9b/lib/classes/oauth2/api.php#L357).  The chain follows as such:

- `core\oauth2\service\custom` uses [openidconnect](https://github.com/moodle/moodle/blob/MOODLE_311_STABLE/lib/classes/oauth2/service/custom.php#L20).
- `core\oauth2\discovery\openidconnect` is in the `core\oauth2\discovery` namespace, and those uses the [base definition](https://github.com/moodle/moodle/blob/911f9adccfc032af277fe3befd02ad5a99cbde9b/lib/classes/oauth2/discovery/base_definition.php#L87-L141) of `discover_endpoints`.

So in the end, with this new code, a `core\oauth2\service\custom` gets returned, which means the call to the `discover_endpoints` happens on the [base definition](https://github.com/moodle/moodle/blob/911f9adccfc032af277fe3befd02ad5a99cbde9b/lib/classes/oauth2/discovery/base_definition.php#L87-L141).